### PR TITLE
Add CI acceptance tests

### DIFF
--- a/.github/ci/docker-compose.yml
+++ b/.github/ci/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       retries: 10
 
   snapcd-server:
-    image: ghcr.io/schrieksoft/snapcd/snapcd-server:1.4.2
+    image: ghcr.io/schrieksoft/snapcd/snapcd-server:1.4.3
     container_name: snapcd-server
     depends_on:
       sqlserver:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,13 +70,33 @@ jobs:
         env:
           SNAPCD_LICENSE_KEY: ${{ secrets.SNAPCD_IO_LICENSE_KEY }}
         run: |
-          TOKEN=$(curl -sf -X POST http://localhost:8080/connect/token \
+          echo "--- Token request ---"
+          TOKEN_RESPONSE=$(curl -s -X POST http://localhost:8080/connect/token \
             -d "grant_type=client_credentials&client_id=10000000-0000-0000-0000-000000000000:debugTerraformer&client_secret=debugTerraformer&scope=snapcd_scope" \
-            | jq -r '.access_token')
-          curl -sf -X POST "http://localhost:8080/api/10000000-0000-0000-0000-000000000000/License/activate" \
+            -w "\nHTTP_STATUS:%{http_code}")
+          TOKEN_BODY=$(echo "$TOKEN_RESPONSE" | sed '$d')
+          TOKEN_STATUS=$(echo "$TOKEN_RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
+          echo "Token status: $TOKEN_STATUS"
+          if [ "$TOKEN_STATUS" != "200" ]; then
+            echo "Token request failed: $TOKEN_BODY"
+            exit 1
+          fi
+          TOKEN=$(echo "$TOKEN_BODY" | jq -r '.access_token')
+          echo "Token obtained (length: ${#TOKEN})"
+          echo "--- License activation ---"
+          ACTIVATE_RESPONSE=$(curl -s -X POST "http://localhost:8080/api/10000000-0000-0000-0000-000000000000/License/activate" \
             -H "Authorization: Bearer $TOKEN" \
             -H "Content-Type: application/json" \
-            -d "{\"licenseKey\": \"$SNAPCD_LICENSE_KEY\"}"
+            -d "{\"licenseKey\": \"$SNAPCD_LICENSE_KEY\"}" \
+            -w "\nHTTP_STATUS:%{http_code}")
+          ACTIVATE_BODY=$(echo "$ACTIVATE_RESPONSE" | sed '$d')
+          ACTIVATE_STATUS=$(echo "$ACTIVATE_RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
+          echo "Activation status: $ACTIVATE_STATUS"
+          echo "Activation response: $ACTIVATE_BODY"
+          if [ "$ACTIVATE_STATUS" != "200" ]; then
+            echo "License activation failed"
+            exit 1
+          fi
 
       - name: Run acceptance tests
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
           SNAPCD_LICENSE_KEY: ${{ secrets.SNAPCD_IO_LICENSE_KEY }}
         run: |
           TOKEN=$(curl -sf -X POST http://localhost:8080/connect/token \
-            -d "grant_type=client_credentials&client_id=debugTerraformer&client_secret=debugTerraformer&scope=snapcd_scope" \
+            -d "grant_type=client_credentials&client_id=10000000-0000-0000-0000-000000000000:debugTerraformer&client_secret=debugTerraformer&scope=snapcd_scope" \
             | jq -r '.access_token')
           curl -sf -X POST "http://localhost:8080/api/10000000-0000-0000-0000-000000000000/License/activate" \
             -H "Authorization: Bearer $TOKEN" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     paths-ignore:
       - "README.md"
-  push:
-    branches:
-      - 'feature/**'
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths-ignore:
       - "README.md"
+  push:
+    branches:
+      - 'feature/**'
 
 permissions:
   contents: read
@@ -22,10 +25,10 @@ jobs:
       - run: go mod download
       - run: go build -v .
       - run: go vet ./...
-      - name: Run linters
-        uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
-          version: v1.64.8
+          python-version: "3.12"
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   test:
     name: Acceptance Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,18 @@ jobs:
           docker compose -f .github/ci/docker-compose.yml logs snapcd-server
           exit 1
 
+      - name: Activate license
+        env:
+          SNAPCD_LICENSE_KEY: ${{ secrets.SNAPCD_IO_LICENSE_KEY }}
+        run: |
+          TOKEN=$(curl -sf -X POST http://localhost:8080/connect/token \
+            -d "grant_type=client_credentials&client_id=debugTerraformer&client_secret=debugTerraformer&scope=snapcd_scope" \
+            | jq -r '.access_token')
+          curl -sf -X POST "http://localhost:8080/api/10000000-0000-0000-0000-000000000000/License/activate" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"licenseKey\": \"$SNAPCD_LICENSE_KEY\"}"
+
       - name: Run acceptance tests
         env:
           TF_ACC: "1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
       - run: go mod download
       - run: go build -v .
       - run: go vet ./...
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.12"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,11 @@ repos:
         language: system
         pass_filenames: false # setting this to "false" means the hook will only run once per commit, *not* once per file
 
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.64.8
+    hooks:
+      - id: golangci-lint
+
   # terraform
   # NOTE this repo has other terraform-related hooks that we could consider using, include "infracost" that produces cloud cost estimates
   - repo: https://github.com/antonbabenko/pre-commit-terraform


### PR DESCRIPTION
Closes #18

## Summary

- Add a license activation step to the CI workflow that authenticates as `debugTerraformer` and activates an enterprise license from a GitHub secret (`SNAPCD_IO_LICENSE_KEY`)
- Run `pre-commit` hooks in the build job
- Add `golangci-lint` as a pre-commit hook
- Bump the CI SnapCD server image from 1.4.2 to 1.4.3
- Restrict the workflow trigger to `pull_request` only (remove `push` on `feature/**`)

## Changes

| File | Change |
|---|---|
| `.github/workflows/test.yml` | Add license activation step with verbose error reporting; add pre-commit hooks to build job; remove push trigger for feature branches |
| `.github/ci/docker-compose.yml` | Bump server image to 1.4.3 |
| `.pre-commit-config.yaml` | Add golangci-lint hook (v1.64.8) |

## License activation flow

The new "Activate license" step:
1. Requests an OAuth token using the org-prefixed client_id `10000000-0000-0000-0000-000000000000:debugTerraformer`
2. Calls `POST /api/{orgId}/License/activate` with the license key from `SNAPCD_IO_LICENSE_KEY` secret
3. Reports HTTP status and response body for both steps on failure